### PR TITLE
Integrate with WPML to support multilanguage

### DIFF
--- a/elevio.php
+++ b/elevio.php
@@ -5,7 +5,7 @@ Plugin URI: https://elev.io/
 Description: A better way for your users to access the help they need.
 Author: Elevio
 Author URI: https://elev.io
-Version: 4.2.0
+Version: 4.1.0
 */
 
 function elevio_posts_tax_query($tax_query)
@@ -41,10 +41,28 @@ add_filter( 'elevio_retrieve_categories_in_all_languages', 'elevio_retrieve_cate
 add_filter( 'elevio_append_language_id_to_article', 'elevio_append_language_id_to_article', 10, 2 );
 add_filter( 'elevio_add_article_filters', 'elevio_add_article_filters', 10, 2 );
 add_filter( 'elevio_aggregate_translated_articles', 'elevio_aggregate_translated_articles' );
-
+add_filter( 'elevio_aggregate_translated_categories', 'elevio_aggregate_translated_categories', 10, 2 );
 
 /**
- * Aggregate the translated article and make all tied to the same article
+ * Aggregate the translated categories
+ * @param $categories
+ * @param $cat_type
+ *
+ * @return mixed
+ */
+function elevio_aggregate_translated_categories( $categories, $cat_type ) {
+	global $sitepress;
+	$default_language = $sitepress->get_default_language();
+	foreach ( $categories as $key => $category ) {
+		$category_id            = wpml_object_id_filter( $category->id, $cat_type, true, $default_language );
+		$categories[ $key ]->id = $category_id;
+	}
+
+	return $categories;
+}
+
+/**
+ * Aggregate the translated articles
  * @param $posts
  *
  * @return mixed

--- a/elevio.php
+++ b/elevio.php
@@ -5,7 +5,7 @@ Plugin URI: https://elev.io/
 Description: A better way for your users to access the help they need.
 Author: Elevio
 Author URI: https://elev.io
-Version: 4.1.0
+Version: 4.2.0
 */
 
 function elevio_posts_tax_query($tax_query)
@@ -36,4 +36,121 @@ function elevio_sync_init()
 
 if (isset($_REQUEST['elevio_sync'])) {
     add_action('wp_loaded', 'elevio_sync_init');
+}
+add_filter( 'elevio_retrieve_categories_in_all_languages', 'elevio_retrieve_categories_in_all_languages', 10, 2 );
+add_filter( 'elevio_append_language_id_to_article', 'elevio_append_language_id_to_article', 10, 2 );
+add_filter( 'elevio_add_article_filters', 'elevio_add_article_filters', 10, 2 );
+add_filter( 'elevio_aggregate_translated_articles', 'elevio_aggregate_translated_articles' );
+
+
+/**
+ * Aggregate the translated article and make all tied to the same article
+ * @param $posts
+ *
+ * @return mixed
+ */
+function elevio_aggregate_translated_articles( $posts ) {
+	global $sitepress;
+	$post_type        = Elevio::get_instance()->get_post_taxonomy();
+	$default_language = $sitepress->get_default_language();
+	foreach ( $posts as $key => $post ) {
+		$post_id           = wpml_object_id_filter( $post->id, $post_type, true, $default_language );
+		$posts[ $key ]->id = $post_id;
+	}
+
+	return $posts;
+}
+
+/**
+ * Append more filters on articles
+ * @param $filters
+ *
+ * @return mixed
+ */
+function elevio_add_article_filters( $filters ) {
+	$filters['suppress_filters'] = true;
+	return $filters;
+}
+
+/**
+ * Append language id to article
+ * @param $post
+ * @param $post_id
+ *
+ * @return mixed
+ */
+function elevio_append_language_id_to_article( $post, $post_id ) {
+
+	$language_code = elevio_get_language_code( $post_id );
+	if ( $language_code ) {
+		$post->language_id = $language_code;
+	}
+
+	return $post;
+}
+
+/**
+ * Get the language of the post
+ * @param $post_id
+ *
+ * @return false|mixed
+ */
+function elevio_get_language_code( $post_id ) {
+	if ( ! has_filter( 'wpml_post_language_details' ) ) {
+		return false;
+	}
+
+	$output = apply_filters( 'wpml_post_language_details', null, $post_id );
+	if ( is_array( $output ) && isset( $output['language_code'] ) ) {
+		return $output['language_code'];
+	}
+
+	return false;
+}
+
+/**
+ * Append language id to all categories using the WPML methods
+ * @param $categories
+ * @param $args
+ *
+ * @return mixed
+ */
+function elevio_retrieve_categories_in_all_languages( $categories, $args ) {
+
+	// Append active language to categories
+	foreach ( $categories as $key => $category ) {
+		$categories[ $key ]->language_id = ICL_LANGUAGE_CODE;
+	}
+
+	global $sitepress;
+	$args['taxonomy'] = Elevio::get_instance()->get_category_taxonomy();
+
+	// Loop on available languages
+	foreach ( $sitepress->get_active_languages() as $active_language ) {
+		$language_code = $active_language['code'];
+
+		// Escape getting the default language
+		if ( ICL_LANGUAGE_CODE === $language_code ) {
+			continue;
+		}
+
+		// Change site language by code
+		do_action( 'wpml_switch_language', $language_code );
+		$wp_categories = get_categories( $args );
+
+		// Loop on categories and append the language ID
+		foreach ( $wp_categories as $wp_category ) {
+			if ( $wp_category->term_id == 1 && $wp_category->slug == 'uncategorized' && $args['taxonomy'] == 'category' ) {
+				continue;
+			}
+			$category              = new Elevio_Sync_Category( $wp_category );
+			$category->language_id = $language_code;
+			$categories[]          = $category;
+		}
+	}
+
+	// Reset to default site language
+	do_action( 'wpml_switch_language', ICL_LANGUAGE_CODE );
+
+	return $categories;
 }

--- a/plugin_files/Elevio.class.php
+++ b/plugin_files/Elevio.class.php
@@ -76,6 +76,27 @@ class Elevio
     }
 
     /**
+     * Returns true if Elevio support multilanguage,
+     * false otherwise.
+     *
+     * @return bool
+     */
+    public function multi_language_is_enabled()
+    {
+        return get_option('elevio_multi_language_is_enabled', false);
+    }
+
+    /**
+     * Aggregate WP posts with translation all tied to that same article
+     *
+     * @return bool
+     */
+    public function aggregate_translated_articles()
+    {
+        return get_option('elevio_aggregated_translated_articles', false);
+    }
+
+    /**
      * Returns true if Elevio account id set properly,
      * false otherwise.
      *

--- a/plugin_files/ElevioAdmin.class.php
+++ b/plugin_files/ElevioAdmin.class.php
@@ -140,6 +140,8 @@ final class ElevioAdmin extends Elevio
         delete_option('elevio_account_id');
         delete_option('elevio_secret_id');
         delete_option('elevio_is_enabled');
+        delete_option('elevio_multi_language_is_enabled');
+        delete_option('elevio_aggregated_translated_articles');
         delete_option('elevio_category_taxonomy');
         delete_option('elevio_post_taxonomy');
         delete_option('elevio_tag_taxonomy');
@@ -164,6 +166,14 @@ final class ElevioAdmin extends Elevio
 
         if (isset($data['elevio_enable_form'])) {
             update_option('elevio_is_enabled', (bool) $data['elevio_is_enabled']);
+        }
+
+        if (isset($data['elevio_multi_language_is_enabled'])) {
+            update_option('elevio_multi_language_is_enabled', (bool) $data['elevio_multi_language_is_enabled']);
+        }
+
+        if (isset($data['elevio_aggregated_translated_articles'])) {
+            update_option('elevio_aggregated_translated_articles', (bool) $data['elevio_aggregated_translated_articles']);
         }
 
         if (isset($data['elevio_category_taxonomy'])) {

--- a/plugin_files/ElevioSync.class.php
+++ b/plugin_files/ElevioSync.class.php
@@ -34,7 +34,11 @@ class ElevioSync
 
 	    if ( $this->is_multilanguage_allowed() ) {
 	        // Integrate with WPML
-            $categories = apply_filters( 'elevio_retrieve_categories_in_all_languages', $categories, $args );
+		    $categories = apply_filters( 'elevio_retrieve_categories_in_all_languages', $categories, $args );
+	    }
+
+	    if ( $this->is_aggregate_translated_articles_enabled() ) {
+		    $categories = apply_filters( 'elevio_aggregate_translated_categories', $categories, $args['taxonomy'] );
 	    }
 
         return $categories;

--- a/plugin_files/ElevioSync.class.php
+++ b/plugin_files/ElevioSync.class.php
@@ -32,6 +32,11 @@ class ElevioSync
             $categories[] = $category;
         }
 
+	    if ( $this->is_multilanguage_allowed() ) {
+	        // Integrate with WPML
+            $categories = apply_filters( 'elevio_retrieve_categories_in_all_languages', $categories, $args );
+	    }
+
         return $categories;
     }
 
@@ -62,8 +67,13 @@ class ElevioSync
         // Allow the running of some extra filters on the retrieved topics
         $tax_query = apply_filters('elevio_posts_tax_query', $tax_query);
         $_GET['tax_query'] = $tax_query;
+	    $filters = $_GET;
 
-        query_posts(http_build_query($_GET));
+	    if ( $this->is_multilanguage_allowed() ) {
+	        $filters = apply_filters( 'elevio_add_article_filters', $filters);
+	    }
+
+        query_posts(http_build_query($filters));
 
         $output = [];
         while (have_posts()) {
@@ -73,10 +83,19 @@ class ElevioSync
             } else {
                 $new_post = new Elevio_Sync_Post($post);
             }
-            $output[] = $new_post;
+
+	        if ( $this->is_multilanguage_allowed() ) {
+		        $new_post = apply_filters( 'elevio_append_language_id_to_article', $new_post, $post->ID );
+	        }
+
+	        $output[] = $new_post;
         }
 
-        return $output;
+	    if ( $this->is_aggregate_translated_articles_enabled() ) {
+		    $output = apply_filters( 'elevio_aggregate_translated_articles', $output );
+	    }
+
+        return array_values($output);
     }
 
     protected function set_posts_query($query = false)
@@ -107,4 +126,13 @@ class ElevioSync
             do_action('json_api_query', $wp_query);
         }
     }
+
+	private function is_multilanguage_allowed() {
+		return Elevio::get_instance()->multi_language_is_enabled();
+	}
+
+
+	private function is_aggregate_translated_articles_enabled() {
+		return boolval($this->is_multilanguage_allowed() && Elevio::get_instance()->aggregate_translated_articles());
+	}
 }

--- a/plugin_files/helpers/TrackingCodeInfoHelper.class.php
+++ b/plugin_files/helpers/TrackingCodeInfoHelper.class.php
@@ -78,6 +78,26 @@ class TrackingCodeInfoHelper extends ElevioHelper
                                     </select>
                                 </td>
                             </tr>
+                            <tr>
+                                <th scope="row">
+                                    <label for="elevio_multi_language_is_enabled">Support multilanguage:</label>
+                                </th>
+                                <td>
+                                    <input type="hidden" name="elevio_multi_language_is_enabled" value="0">
+                                    <input type="checkbox" name="elevio_multi_language_is_enabled" id="elevio_multi_language_is_enabled" value="1" <?php echo Elevio::get_instance()->multi_language_is_enabled() ? 'checked="checked"' : ''; ?> />
+                                    (Integrated with WPML only - you should have WPML to support multilanguage)
+                                </td>
+                            </tr>
+                            <tr>
+                                <th scope="row">
+                                    <label for="elevio_aggregated_translated_articles">Aggregate translated articles:</label>
+                                </th>
+                                <td>
+                                    <input type="hidden" name="elevio_aggregated_translated_articles" value="0">
+                                    <input type="checkbox" name="elevio_aggregated_translated_articles" id="elevio_aggregated_translated_articles" value="1" <?php echo Elevio::get_instance()->aggregate_translated_articles() ? 'checked="checked"' : ''; ?> />
+                                    (Make one Elevio article for each post with translation all tied to that same article - Integrated with WPML only)
+                                </td>
+                            </tr>
 
                         </table>
 

--- a/plugin_files/models/category.php
+++ b/plugin_files/models/category.php
@@ -19,7 +19,7 @@ class Elevio_Sync_Category
     // Integer
   public $post_count;  // Integer
 
-  public function Elevio_Sync_Category($wp_category = null)
+  public function __construct($wp_category = null)
   {
       if ($wp_category) {
           $this->import_wp_object($wp_category);

--- a/plugin_files/models/post.php
+++ b/plugin_files/models/post.php
@@ -64,7 +64,7 @@ class Elevio_Sync_Post
     // String
   public $custom_fields;   // Object (included by using custom_fields query var)
 
-  public function Elevio_Sync_Post($wp_post = null)
+  public function __construct($wp_post = null)
   {
       if (! empty($wp_post)) {
           $this->import_wp_object($wp_post);
@@ -104,7 +104,14 @@ class Elevio_Sync_Post
         $args['taxonomy'] = Elevio::get_instance()->get_category_taxonomy();
         global $json_api;
         $this->categories = [];
-        if ($wp_categories = get_the_terms($this->id, $args['taxonomy'])) {
+
+	    if ( has_filter( 'wpml_object_id' ) ) {
+		    global $sitepress;
+		    $language = elevio_get_language_code( $this->id );
+		    $sitepress->switch_lang( $language );
+	    }
+
+        if ($wp_categories = wp_get_object_terms( $this->id, $args['taxonomy'] )) {
             foreach ($wp_categories as $wp_category) {
                 $category = new Elevio_Sync_Category($wp_category);
                 if ($category->id == 1 && $category->slug == 'uncategorized' && $args['taxonomy'] == 'category') {


### PR DESCRIPTION
#### Feature
- Integrate with WPML to support multilanguage by adding two new checkboxes on the Elevio admin page
    1.  **Support multilanguage** This option will add `language_id` on each article to migrate the articles with the correct language separately.
    2. **Aggregate translated articles** This option will make one Elevio article for each post with translation tied to that same article. (it require you to enable the first option, `Support multilanguage` )
    
#### Notes
- Supporting multilanguage is integrated with WPML only. 